### PR TITLE
Add helper to trigger n8n workflow

### DIFF
--- a/workflow.js
+++ b/workflow.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Triggers a predefined n8n workflow with the provided input payload.
+ *
+ * @param {unknown} input - Arbitrary payload data to forward to n8n.
+ * @returns {Promise<string>} A confirmation message once the workflow is triggered.
+ */
+async function main(input) {
+  const { n8n } = tools;
+
+  await n8n.workflow.trigger('N8N_WORKFLOW_ID', {
+    payload: input,
+  });
+
+  return 'Workflow gestartet.';
+}
+
+module.exports = {
+  main,
+};


### PR DESCRIPTION
## Summary
- add a reusable helper that triggers an n8n workflow with an arbitrary payload
- export the main function so it can be reused elsewhere in the project

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4d440c23083249f88dc05007e1450